### PR TITLE
FIX: when axis with "agg" type received a children object

### DIFF
--- a/MDX2JSON/ResultSet.cls
+++ b/MDX2JSON/ResultSet.cls
@@ -130,7 +130,7 @@ Method ProcessOneAxisCell(CubeIndex, AxisKey, CubeName, QueryKey, AxisNumber, No
 	set cell.vis = $LG(tNode,2) // visibility helper - does not help (apperently it shows if the cell is the lowest level)  
 
 	// now we process cell children, if any exist
-	if ($D($$$DeepSeeAxisGLVN(CubeIndex, AxisKey, "axes", Node, "ch")) = 10) {
+	if ($D($$$DeepSeeAxisGLVN(CubeIndex, AxisKey, "axes", Node, "ch")) = 10) && ($LG(tNode, 1)'="agg") {
 		set cell.children = $$$NewDynObjList
 		set key = $O($$$DeepSeeAxisGLVN(CubeIndex, AxisKey, "axes", Node, "ch", ""))
 		while (key'="") {


### PR DESCRIPTION
When "agg" axis received a children object and it situated as as a column in a pivot with rows dsw couldn't display

Current

`"tuples":[ {
					"caption":"Contests",
					"cellStyle":"",
					"children":[
					],
					"dimension":"Contests",
					"format":"",
					"headerStyle":"",
					"path":"",
					"title":"",
					"total":"",
					"type":"agg",
					"valueID":"%DISTINCT",
					"vis":1
				}
			]`

Expected

`"tuples":[ {
					"caption":"Contests",
					"cellStyle":"",
					"dimension":"Contests",
					"format":"",
					"headerStyle":"",
					"path":"",
					"title":"",
					"total":"",
					"type":"agg",
					"valueID":"%DISTINCT",
					"vis":1
				}
			]`